### PR TITLE
Reimplement and finish use of "InRelease.tmp" (removed in a previous commit)

### DIFF
--- a/repo_lib/__init__.py
+++ b/repo_lib/__init__.py
@@ -232,11 +232,12 @@ class Repository:
                     "--clearsign",
                     "--output",
                     release_files["InRelease"],
-                    release_files["Release"],
+                    release_files["InRelease.tmp"],
                 ],
             ):
                 run_cmd([*gpg_cmd, *gpg_args])
         log_msg = ["Release file generated"]
         if gpgkey:
             log_msg.append(", InRelease file generated and both signed")
+            os.remove(release_files["InRelease.tmp"])
         logger.debug("".join(log_msg))


### PR DESCRIPTION
I just noticed that I overlooked the point of writing an [`InRelease.tmp`](https://github.com/JedMeister/repo/blob/281fd5532af63d3a84b52f35c752fc1b03ed2134/repo_lib/__init__.py#L210-L216) file in my original code. It's the contents of the `Release` file, but with an addition at the top.

Prior to this commit, the tmp file was still being written, but not used as the basis of the `InRelease` file - nor being cleaned up afterwards.