### PR TITLE
Force pybuild to not create __pycache__ files at build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,6 @@
 #! /usr/bin/make -f
 
-export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export PYTHONDONTWRITEBYTECODE=1
 
 %:
 	dh $@ --buildsystem=pybuild


### PR DESCRIPTION
Minimal change to make repo reproducible.

FYI DEB_BUILD_MAINT_OPTIONS are only relevant to packages that are built from C/C++ source and have no impact on pure python source.