### PR TITLE
actually this doesn't need to be manually added

### DIFF
--- a/repo_lib/__init__.py
+++ b/repo_lib/__init__.py
@@ -210,7 +210,6 @@ class Repository:
             with open(release_files["InRelease.tmp"], "w") as inrelease_fob:
                 # not sure exactly what 'Hash' at the top means/does, but
                 # following Debian's lead
-                inrelease_fob.write("Hash: SHA256\n\n")
                 with open(release_files["Release"]) as release_fob:
                     for line in release_fob:
                         inrelease_fob.write(line)


### PR DESCRIPTION
It turns out that the `Hash ...` line at the top of the InRelease file does not need to be manually added.