### PR TITLE
"proper" noqa comment

### DIFF
--- a/repo_lib/download.py
+++ b/repo_lib/download.py
@@ -18,8 +18,9 @@ def _run(cmd: list[str], chroot: str = "") -> str:
     """Run a command on the host or inside a chroot; return stdout."""
     if chroot:
         # Imported here so the package is only required when --chroot is used.
-        # - ignored PLC0415 & I001 because import not at top of file.
-        from chroot import Chroot  # type: ignore[import-untyped]  # noqa: PLC0415, I001
+        # Ignored PLC0415 (import-outside-top-level) because import is
+        # intentially conditional.
+        from chroot import Chroot  # noqa: PLC0415
         result = Chroot(chroot).run(
             cmd, capture_output=True, text=True, check=False,
         )


### PR DESCRIPTION
As discussed with @OnGle offline, I jumped the gun merging https://github.com/turnkeylinux/repo/pull/10 because I didn't properly address the requested change.

Also, the type ignore has been removed (turnkey-chroot now includes py.typed) and removed redundant ruff rule ([I001](https://docs.astral.sh/ruff/rules/unsorted-imports/#unsorted-imports-i001)).